### PR TITLE
xthal_set_intenable for non-os SDK

### DIFF
--- a/gdbstub.c
+++ b/gdbstub.c
@@ -72,6 +72,7 @@ the xthal stack frame struct.
 
 void _xtos_set_exception_handler(int cause, void (exhandler)(struct XTensa_exception_frame_s *frame));
 int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+void xthal_set_intenable(unsigned);
 
 #endif
 
@@ -562,6 +563,7 @@ void ATTR_GDBFN gdbstub_handle_debug_exception() {
 	ets_wdt_disable();
 
 	sendReason();
+	xthal_set_intenable(0); // enable receiving UART bytes without interrupts
 	while(gdbReadCommand()!=ST_CONT);
 	if ((gdbstub_savedRegs.reason&0x84)==0x4) {
 		//We stopped due to a watchpoint. We can't re-execute the current instruction
@@ -614,6 +616,7 @@ static void ATTR_GDBFN gdb_exception_handler(struct XTensa_exception_frame_s *fr
 
 	ets_wdt_disable();
 	sendReason();
+	xthal_set_intenable(0); // enable receiving UART bytes without interrupts
 	while(gdbReadCommand()!=ST_CONT);
 	ets_wdt_enable();
 
@@ -693,6 +696,7 @@ static void ATTR_GDBFN uart_hdlr(void *arg, void *frame) {
 	
 		ets_wdt_disable();
 		sendReason();
+		xthal_set_intenable(0); // enable receiving UART bytes without interrupts
 		while(gdbReadCommand()!=ST_CONT);
 		ets_wdt_enable();
 		//Copy any changed registers back to the frame the Xtensa HAL uses.


### PR DESCRIPTION
xthal_set_intenable(0) be there otherwise many incoming bytes are lost making it completely non-functional!
