### PR TITLE
Fix packet end not being sent for some exception types

### DIFF
--- a/gdbstub.c
+++ b/gdbstub.c
@@ -298,7 +298,7 @@ static void ATTR_GDBFN sendReason() {
 	} else if (gdbstub_savedRegs.reason&0x80) {
 		//We stopped because of an exception. Convert exception code to a signal number and send it.
 		i=gdbstub_savedRegs.reason&0x7f;
-		if (i<sizeof(exceptionSignal)) return gdbPacketHex(exceptionSignal[i], 8); else gdbPacketHex(11, 8);
+		if (i<sizeof(exceptionSignal)) gdbPacketHex(exceptionSignal[i], 8); else gdbPacketHex(11, 8);
 	} else {
 		//We stopped because of a debugging exception.
 		gdbPacketHex(5, 8); //sigtrap


### PR DESCRIPTION
Calling `return gdbPacketHex(...)` resulted in `gdbPacketEnd()` not being called.
This caused an incomplete packet sent to the host, which complained and closed connection.