### PR TITLE
guard ATTR_GDBFN against redefinition as all the other #defines

### DIFF
--- a/gdbstub-cfg.h
+++ b/gdbstub-cfg.h
@@ -56,7 +56,9 @@ are called when the flash is disabled (eg due to a Ctrl-C at the wrong time), th
 likely crash.
 */
 #define ATTR_GDBINIT	ICACHE_FLASH_ATTR
+#ifndef ATTR_GDBFN
 #define ATTR_GDBFN		
+#endif
 
 #endif
 


### PR DESCRIPTION
We should guard ATTR_GDBFN against redefinition like the other defines to make it possible to set them in the Makefile, thus we do not have to change the gdbstub-cfg.h at all.
