### PR TITLE
Fixed typo in the cplusplus closing part.

### DIFF
--- a/gdbstub-entry.h
+++ b/gdbstub-entry.h
@@ -16,10 +16,10 @@ int gdbstub_set_hw_watchpoint(int addr, int len, int type);
 int gdbstub_del_hw_breakpoint(int addr);
 int gdbstub_del_hw_watchpoint(int addr);
 
-extern void* gdbstub_do_break_breakpoint_addr;
+void* gdbstub_do_break_breakpoint_addr;
 
 #ifdef __cplusplus
-{
+}
 #endif
 
 #endif


### PR DESCRIPTION
Removed redundant `extern`.